### PR TITLE
Fix localhost default settings

### DIFF
--- a/nanoscope_workstation_install.sh
+++ b/nanoscope_workstation_install.sh
@@ -230,7 +230,7 @@ install_nanoscope() {
     local_clustersettings_file="${cluster_settings_dir}/Local.clustersettings"
     cat <<EOF > "$local_clustersettings_file"
 {
-    "resource_name": "localhost",
+    "resource_name": "Local",
     "walltime": "86399",
     "cpus_per_node": "$(nproc)",
     "nodes": "1",


### PR DESCRIPTION
The client uses resource_name internally. This has to be the same as filename, otherwise you will encounter errors in the client. The client does not derive this from the filename itself.

This MIGHT have lead to the connected_resource thing, but maybe it also didn't.